### PR TITLE
🐛 Fix missing quote rate from Coingecko

### DIFF
--- a/scheduler/app/libs/tasks/get_assets.py
+++ b/scheduler/app/libs/tasks/get_assets.py
@@ -32,9 +32,7 @@ async def get_token_hist_prices(treasury: Treasury) -> dict[str, DF]:
         (a.token_symbol, a.token_address) for a in treasury.assets
     } | {("ETH", "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee")}
     maybe_hist_prices = {
-        token_symbol: await coingecko.get_coin_hist_price(
-            token_address, token_symbol, (1, "years")
-        )
+        token_symbol: await coingecko.get_coin_hist_price(token_address, token_symbol)
         for token_symbol, token_address in asset_addresses_including_ETH
     }
     hist_prices = {


### PR DESCRIPTION
Quote rates were going 365 days in the past but our time frame
as already "starting yesterday", so we had a 0 at start.