### PR TITLE
Added correlations between a treasury's assets

### DIFF
--- a/scheduler/app/libs/storage_helpers.py
+++ b/scheduler/app/libs/storage_helpers.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Any, Union
 import redis
 import json
 
@@ -22,16 +22,26 @@ def retrieve_treasuries_metadata() -> list[tuple[str, int]]:
 BALANCES_KEY_TEMPLATE = "{address}_{symbol}"
 
 
+def store_hash_set(
+    set: str,
+    key: str,
+    value: Any,
+    provider: Union[redis.Redis, redis.client.Pipeline] = db,
+):
+    provider.hset(set, key, value)
+
+
 def store_asset_hist_balance(
     treasury_address: str,
     symbol: str,
     asset_hist_balance_json: str,
     provider: Union[redis.Redis, redis.client.Pipeline] = db,
 ):
-    provider.hset(
+    store_hash_set(
         "balances",
         BALANCES_KEY_TEMPLATE.format(address=treasury_address, symbol=symbol),
         asset_hist_balance_json,
+        provider,
     )
 
 
@@ -40,4 +50,14 @@ def store_asset_hist_performance(
     asset_hist_performance_json: str,
     provider: Union[redis.Redis, redis.client.Pipeline] = db,
 ):
-    provider.hset("asset_hist_performance", symbol, asset_hist_performance_json)
+    store_hash_set(
+        "asset_hist_performance", symbol, asset_hist_performance_json, provider
+    )
+
+
+def store_asset_correlations(
+    address: str,
+    asset_correlations_json: str,
+    provider: Union[redis.Redis, redis.client.Pipeline] = db,
+):
+    store_hash_set("asset_correlations", address, asset_correlations_json, provider)

--- a/scheduler/app/libs/tasks/get_assets.py
+++ b/scheduler/app/libs/tasks/get_assets.py
@@ -13,6 +13,7 @@ from .. import bitquery
 from ..storage_helpers import (
     store_asset_hist_balance,
     store_asset_hist_performance,
+    store_asset_correlations,
     retrieve_treasuries_metadata,
 )
 from . import db, celery_app
@@ -25,6 +26,7 @@ from .treasury_ops import (
     apply_spread_percentages,
     populate_bitquery_hist_eth_balance,
     populate_hist_tres_balance,
+    calculate_correlations,
     calculate_risk_contributions,
 )
 
@@ -359,4 +361,13 @@ def reload_treasuries_data():
                     asset_hist_balance.to_json(orient="records"),
                     provider=pipe,
                 )
+
+            store_asset_correlations(
+                treasury.address,
+                calculate_correlations(
+                    treasury, augmented_token_hist_prices, start, end
+                ).to_json(orient="index"),
+                provider=pipe,
+            )
+
             pipe.execute()

--- a/scheduler/app/libs/tasks/treasury_ops.py
+++ b/scheduler/app/libs/tasks/treasury_ops.py
@@ -159,7 +159,9 @@ def get_returns_matrix(
     treasury: Treasury, augmented_token_hist_prices: Dict[str, DF], start: str, end: str
 ):
     hist_prices_items = [
-        (symbol, hist_prices.set_index("timestamp").loc[start:end].reset_index())
+        # sorting index before querying by daterange to suppress PD Future Warning
+        # ; non-monotonic timeseries issue suppresed
+        (symbol, hist_prices.set_index("timestamp").sort_index().loc[start:end].reset_index())
         for symbol, hist_prices in augmented_token_hist_prices.items()
     ]
 
@@ -229,6 +231,14 @@ def calculate_risk_contributions(
         asset.risk_contribution = percentage
 
     return treasury
+
+
+def calculate_correlations(
+    treasury: Treasury, augmented_token_hist_prices: Dict[str, DF], start: str, end: str
+):
+    returns_matrix = get_returns_matrix(treasury, augmented_token_hist_prices, start, end)
+
+    return returns_matrix.corr()
 
 
 def apply_spread_percentages(


### PR DESCRIPTION
## Summary
Using the [Pearson Strategy](https://en.wikipedia.org/wiki/Pearson_correlation_coefficient), the correlations between a given treasury's assets was calculated from a given dataset containing series of historical asset prices.

The `reload_treasuries_data` Celery task now also caches this correlation matrix onto Redis under the `asset_correlations` hash, the keys for this hash table are the treasuries' address.

## Visual Preview

```bash
localhost:6379> hgetall asset_correlations
1) "0x1a9c8182c09f50c8318d769245bea52c32be35bc"
2) "{\"UNI\":{\"UNI\":1.0}}"
3) "0x78605df79524164911c144801f41e9811b7db73d"
4) "{\"ETH\":{\"ETH\":1.0,\"BIT\":0.7177731346,\"USDC\":0.1127554681,\"FTX Token\":0.8045793107,\"USDT\":0.0776166171},\"BIT\":{\"ETH\":0.7177731346,\"BIT\":1.0,\"USDC\":0.1290972479,\"FTX Token\":0.6258481745,\"USDT\":0.0203246917},\"USDC\":{\"ETH\":0.1127554681,\"BIT\":0.1290972479,\"USDC\":1.0,\"FTX Token\":0.1389417122,\"USDT\":0.4527777701},\"FTX Token\":{\"ETH\":0.8045793107,\"BIT\":0.6258481745,\"USDC\":0.1389417122,\"FTX Token\":1.0,\"USDT\":0.1251028046},\"USDT\":{\"ETH\":0.0776166171,\"BIT\":0.0203246917,\"USDC\":0.4527777701,\"FTX Token\":0.1251028046,\"USDT\":1.0}}"
localhost:6379>
```