### PR TITLE
Fixed blank chart errors and incorrect covalent response handling

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       - scheduler/app.env
     volumes:
       - ./scheduler/app/:/app/app/
-    command: "celery -A app.celery_main worker --concurrency=1 -l INFO --pidfile= --logfile=/var/log/celery/%n%I.log"
+    command: "celery -A app.celery_main worker --concurrency=1 -B -l INFO --pidfile= --logfile=/var/log/celery/%n%I.log"
   frontend:
     profiles: ["frontend"]
     image: butter_whip/frontend:dev

--- a/scheduler/app/libs/bitquery.py
+++ b/scheduler/app/libs/bitquery.py
@@ -54,13 +54,17 @@ async def get_eth_transactions(address: str) -> list[BitqueryTransfer]:
                     json={"query": ETH_QUERY_TEMPLATE.replace("$address", address)},
                 )
                 resp.raise_for_status()
-                return resp.json()["data"]["ethereum"]["address"][0]["balances"][0][
-                    "history"
-                ]
+                try:
+                  return resp.json()["data"]["ethereum"]["address"][0]["balances"][0][
+                      "history"
+                  ]
+                except TypeError as e:
+                  return None
 
         balance_hist_data = await get_balance_hist_data()
         db.hset(CACHE_HASH, cache_key, json.dumps(balance_hist_data))
-
+    if not balance_hist_data:
+      return None 
     return [
         BitqueryTransfer(
             dateutil.parser.parse(hist_item["timestamp"]),

--- a/scheduler/app/libs/coingecko/coins.py
+++ b/scheduler/app/libs/coingecko/coins.py
@@ -1,11 +1,9 @@
 import json
 from json.decoder import JSONDecodeError
 from time import sleep
-from typing import List, Tuple, Union
 
 from billiard.pool import MaybeEncodingError
 from httpx import AsyncClient, Timeout
-import json
 import dateutil.utils
 import dateutil.tz
 import datetime
@@ -58,7 +56,7 @@ async def get_coin_hist_price(
                 f"https://api.coingecko.com/api/v3/coins/ethereum/contract/{contract_address}/market_chart/range?vs_currency=usd&from={start_date.timestamp()}&to={end_date.timestamp()}",
                 timeout=timeout,
             )
-        except MaybeEncodingError as e:
+        except MaybeEncodingError:
             sleep(5)
             resp = await client.get(
                 f"https://api.coingecko.com/api/v3/coins/ethereum/contract/{contract_address}/market_chart/range?vs_currency=usd&from={start_date.timestamp()}&to={end_date.timestamp()}",
@@ -67,7 +65,7 @@ async def get_coin_hist_price(
         sleep(5)
         try:
             prices = resp.json().get("prices")
-        except JSONDecodeError as e:
+        except JSONDecodeError:
             print(f"decode error for {resp.url}")
             return None
 

--- a/scheduler/app/libs/covalent/historical_prices.py
+++ b/scheduler/app/libs/covalent/historical_prices.py
@@ -20,7 +20,6 @@ async def get_historical_price_by_symbol(
         start_date = start_date.strftime("%Y-%m-%d")
 
     async with AsyncClient() as client:
-        # api.covalenthq.com/v1/pricing/historical/USD/UNI/?quote-currency=USD&format=JSON&from=2021-05-10&key=ckey_30f56650f3a544fe8803d522cb0
         resp = await client.get(
             f"https://api.covalenthq.com/v1/pricing/historical/"
             + f"{quote}/{token_symbol}/?key=ckey_{getenv('COVALENT_KEY')}"
@@ -29,7 +28,6 @@ async def get_historical_price_by_symbol(
             + f"&from={start_date}"
         )
 
-        # print("url: ", resp.url)
         return resp.json()["data"]
 
 

--- a/scheduler/app/libs/covalent/treasury.py
+++ b/scheduler/app/libs/covalent/treasury.py
@@ -22,7 +22,7 @@ async def get_treasury_portfolio(
     if db.hexists(CACHE_HASH, cache_key):
         return json.loads(db.hget(CACHE_HASH, cache_key))
 
-    timeout = Timeout(10.0, read=15.0, connect=30.0)
+    timeout = Timeout(10.0, read=30.0, connect=45.0)
     async with AsyncClient(timeout=timeout) as client:
         resp = await client.get(
             f"https://api.covalenthq.com/v1/{chain_id}/address/{treasury_address}/"
@@ -55,7 +55,7 @@ async def get_treasury(portfolio: Dict[str, Any]) -> Treasury:
             )
         )
 
-    # These tokens do don receive a valid response from covalent's
+    # These tokens don't receive a valid response from covalent's
     # portfolio balances. So we blacklist them
     blacklist = [
         "0x6a113e4caa8aa29c02e535580027a1a3203f43fb"  # mEth

--- a/scheduler/app/libs/covalent/treasury.py
+++ b/scheduler/app/libs/covalent/treasury.py
@@ -55,13 +55,6 @@ async def get_treasury(portfolio: Dict[str, Any]) -> Treasury:
             )
         )
 
-    # These tokens don't receive a valid response from covalent's
-    # portfolio balances. So we blacklist them
-    blacklist = [
-        "0x6a113e4caa8aa29c02e535580027a1a3203f43fb"  # mEth
-        , "0x7cf56db0f7781d478d5a96f6ee8e0b5cbaaf8ad2"  # OMIC / Omicron
-    ]
-
     assets = [
         ERC20(
             item["contract_name"],
@@ -71,8 +64,8 @@ async def get_treasury(portfolio: Dict[str, Any]) -> Treasury:
         )
         for item in portfolio["items"]
         if item["holdings"][0]["close"]["quote"]
-            and
-        item["contract_address"] not in blacklist
+        and
+        item['holdings'][0]['quote_rate'] < 10 ** 18
     ]
 
     return Treasury(portfolio["address"], assets, windows)

--- a/scheduler/app/libs/covalent/treasury.py
+++ b/scheduler/app/libs/covalent/treasury.py
@@ -55,6 +55,13 @@ async def get_treasury(portfolio: Dict[str, Any]) -> Treasury:
             )
         )
 
+    # These tokens do don receive a valid response from covalent's
+    # portfolio balances. So we blacklist them
+    blacklist = [
+        "0x6a113e4caa8aa29c02e535580027a1a3203f43fb"  # mEth
+        , "0x7cf56db0f7781d478d5a96f6ee8e0b5cbaaf8ad2"  # OMIC / Omicron
+    ]
+
     assets = [
         ERC20(
             item["contract_name"],
@@ -64,6 +71,8 @@ async def get_treasury(portfolio: Dict[str, Any]) -> Treasury:
         )
         for item in portfolio["items"]
         if item["holdings"][0]["close"]["quote"]
+            and
+        item["contract_address"] not in blacklist
     ]
 
     return Treasury(portfolio["address"], assets, windows)

--- a/scheduler/app/libs/tasks/get_assets.py
+++ b/scheduler/app/libs/tasks/get_assets.py
@@ -235,12 +235,7 @@ def augment_spread_treasury(
         b.loc[end].balance for b in spread_asset_hist_balances.values()
     )
     for asset in spread_treasury.assets:
-        try:
             asset.balance = spread_asset_hist_balances[asset.token_symbol].loc[end].balance
-        except KeyError as e:
-            print(f"unable to get balance of asset {asset.token_symbol} from spread treasury")
-            print_exception(type(e), e, e.__traceback__)
-            continue
 
     augmented_total_balance = augment_total_balance(
         spread_treasury, spread_asset_hist_balances

--- a/scheduler/app/libs/tasks/get_assets.py
+++ b/scheduler/app/libs/tasks/get_assets.py
@@ -94,7 +94,8 @@ async def get_sparse_asset_hist_balances(treasury: Treasury) -> dict[str, Series
     return {
         symbol: hist
         for symbol, hist in maybe_sparse_asset_hist_balances.items()
-        if hist is not None and not hist.empty
+        if hist is not None
+            and not hist.empty
     }
 
 

--- a/scheduler/app/libs/tasks/get_assets.py
+++ b/scheduler/app/libs/tasks/get_assets.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from datetime import timedelta
+from traceback import print_exception
 from dateutil.utils import today
 from dateutil.tz import UTC
 from functools import reduce
@@ -233,7 +234,12 @@ def augment_spread_treasury(
         b.loc[end].balance for b in spread_asset_hist_balances.values()
     )
     for asset in spread_treasury.assets:
-        asset.balance = spread_asset_hist_balances[asset.token_symbol].loc[end].balance
+        try:
+            asset.balance = spread_asset_hist_balances[asset.token_symbol].loc[end].balance
+        except KeyError as e:
+            print(f"unable to get balance of asset {asset.token_symbol} from spread treasury")
+            print_exception(type(e), e, e.__traceback__)
+            continue
 
     augmented_total_balance = augment_total_balance(
         spread_treasury, spread_asset_hist_balances

--- a/scheduler/app/libs/tasks/treasury_ops.py
+++ b/scheduler/app/libs/tasks/treasury_ops.py
@@ -258,7 +258,7 @@ def apply_spread_percentages(
     start: str,
 ) -> dict[str, DF]:
     start_balance = sum(
-        asset_hist_balance.loc[start].balance
+        asset_hist_balance.set_index("timestamp").sort_index().loc[start].balance
         for asset_hist_balance in asset_hist_balances.values()
     )
     start_balance_except_spread_token = sum(

--- a/scheduler/app/libs/tasks/treasury_ops.py
+++ b/scheduler/app/libs/tasks/treasury_ops.py
@@ -148,6 +148,9 @@ async def populate_hist_tres_balance(
 
 
 def populate_bitquery_hist_eth_balance(eth_transfers: list[BitqueryTransfer]) -> Series:
+    # return an empty Series if there are no ETH/native token transfers
+    if not eth_transfers: return Series(dtype="object")
+
     index = MultiIndex.from_tuples(
         [
             (bt.timestamp, "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee", "ETH")

--- a/scheduler/app/libs/tasks/treasury_ops.py
+++ b/scheduler/app/libs/tasks/treasury_ops.py
@@ -1,7 +1,6 @@
-from datetime import datetime
-from sys import dont_write_bytecode
 from dateutil import parser
 from math import log, isclose
+from traceback import print_exception
 from typing import Any, Dict, List, Optional
 from functools import reduce
 
@@ -19,6 +18,10 @@ def add_statistics(
     index: Optional[str] = None,
 ):
     df = df.reset_index()
+    try:
+        symbol = df["symbol"][0]
+    except KeyError as _:
+        symbol = "Balances"
 
     """ `returns` calculation section
 
@@ -32,7 +35,14 @@ def add_statistics(
         if prev == 0 or current == 0:
             returns.append(0)
         else:
-            returns.append(log(current / prev))
+            _return: float = None
+            try:
+                _return = log(current / prev)
+            except ValueError as e:
+                print(f"unable to set return (ln(curr/prev)) for {symbol}")
+                print_exception(type(e), e, e.__traceback__)
+                print(f"curr: {current}, prev: {prev}")
+            returns.append(_return)
     df["returns"] = returns
 
     """ end section
@@ -222,7 +232,7 @@ def calculate_risk_contributions(
     assert isclose(
         summed_component_contributions, std_dev[0][0], rel_tol=0.0001
     ), "error in calculations"
-    print(f"component_contributions: {component_contributions}")
+    # print(f"component_contributions: {component_contributions}")
 
     component_percentages = component_contributions / std_dev[0][0]
 

--- a/scheduler/app/main.py
+++ b/scheduler/app/main.py
@@ -1,4 +1,5 @@
 import datetime
+from traceback import print_exception
 from typing import Iterable, Literal, TypeVar, Union
 import dateutil
 from pytz import UTC
@@ -57,14 +58,22 @@ class Portfolio:
         }
         totalbalance = augmented_total_balance.loc[start:end]
 
-        assets = {
-            a.token_symbol: PortfolioAsset(
-                allocation=a.balance / treasury.usd_total,
-                volatility=histprices[a.token_symbol]["std_dev"].mean(),
-                risk_contribution=a.risk_contribution,
-            )
-            for a in treasury.assets
-        }
+        assets = {}
+        for a in treasury.assets:
+            try:
+                assets.update(
+                    {
+                        a.token_symbol: PortfolioAsset(
+                            allocation=a.balance / treasury.usd_total,
+                            volatility=histprices[a.token_symbol]["std_dev"].mean(),
+                            risk_contribution=a.risk_contribution,
+                        )
+                    }
+                )
+            except KeyError as e:
+                print(f"error in listing asset {a.token_symbol}")
+                print_exception(type(e), e, e.__traceback__)
+                continue
 
         if (start not in totalbalance.index) or (totalbalance.loc[start].balance == 0):
             market_return = "Infinity"


### PR DESCRIPTION
## Summary
Some logical errors were causing certain treasuries inputted into the frontend to return black responses from the backend:

* bitquery ETH transaction history needed to account for wallet addresses which never had ETH transferred  into them (/scheduler/app/libs/bitquery.py).
* certain meme/spam tokens were causing bad/erroneous responses from covalent (/scheduler/app/libs/covalent/treasury.py)
    * causing the historical balances/historical prices in usd to become incorrect
    * additional stats that depend on historical prices needed error handlers to account for this
* need to [account for domain errors](https://github.com/butterdao/whip/compare/fix.gitcoin?expand=1#diff-bfac836801fca00b3f02e1ba4239a32707284ccb38c1f3dffe06284a613b83aeR38-R45) when calculating historical returns for a treasury's balance
* need to account for possible meme/spam tokens not having correct historical values that additional statistics depend on, for example, this API endpoint handler(/scheduler/app/main.py)

p.s. this PR addresses issue #27 