### PR TITLE
:bug: Fixed issue with empty Historical Prices

### DIFF
--- a/backend/app/libs/coingecko/coins.py
+++ b/backend/app/libs/coingecko/coins.py
@@ -40,7 +40,9 @@ async def get_coin_hist_price(
     )
     if db.hexists(CACHE_HASH, cache_key):
         prices = json.loads(db.hget(CACHE_HASH, cache_key))
-        return (contract_address, symbol, prices)
+        if prices is not None:
+            return (contract_address, symbol, prices)
+        return None
 
     timeout = Timeout(10.0, read=15.0, connect=30.0)
     async with AsyncClient(
@@ -71,6 +73,8 @@ async def get_coin_hist_price(
         sleep(5)
         try:
             prices = resp.json().get("prices")
+            if prices is None:
+                return None
         except JSONDecodeError:
             print(f"decode error for {resp.url}")
             return None

--- a/backend/app/libs/tasks/get_assets.py
+++ b/backend/app/libs/tasks/get_assets.py
@@ -45,15 +45,16 @@ async def get_token_hist_prices(treasury: Treasury) -> dict[str, DF]:
     } | {("ETH", "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee")}
     maybe_hist_prices = {}
     for token_symbol, token_address in asset_addresses_including_eth:
-        maybe_hist_price = await coingecko.get_coin_hist_price(token_address, token_symbol)
+        maybe_hist_price = await coingecko.get_coin_hist_price(
+            token_address, token_symbol
+        )
         if not maybe_hist_price:
             treasury.prune(token_symbol)
             continue
         maybe_hist_prices.update({token_symbol: maybe_hist_price})
 
     hist_prices = {
-        symbol: mhp for symbol, mhp in maybe_hist_prices.items()
-        if mhp is not None
+        symbol: mhp for symbol, mhp in maybe_hist_prices.items() if mhp is not None
     }
     return {
         symbol: coingecko.coingecko_hist_df(addr, symbol, prices)

--- a/backend/app/libs/tasks/get_assets.py
+++ b/backend/app/libs/tasks/get_assets.py
@@ -43,12 +43,17 @@ async def get_token_hist_prices(treasury: Treasury) -> dict[str, DF]:
     asset_addresses_including_eth = {
         (a.token_symbol, a.token_address) for a in treasury.assets
     } | {("ETH", "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee")}
-    maybe_hist_prices = {
-        token_symbol: await coingecko.get_coin_hist_price(token_address, token_symbol)
-        for token_symbol, token_address in asset_addresses_including_eth
-    }
+    maybe_hist_prices = {}
+    for token_symbol, token_address in asset_addresses_including_eth:
+        maybe_hist_price = await coingecko.get_coin_hist_price(token_address, token_symbol)
+        if not maybe_hist_price:
+            treasury.prune(token_symbol)
+            continue
+        maybe_hist_prices.update({token_symbol: maybe_hist_price})
+
     hist_prices = {
-        symbol: mhp for symbol, mhp in maybe_hist_prices.items() if mhp is not None
+        symbol: mhp for symbol, mhp in maybe_hist_prices.items()
+        if mhp is not None
     }
     return {
         symbol: coingecko.coingecko_hist_df(addr, symbol, prices)

--- a/backend/app/libs/types.py
+++ b/backend/app/libs/types.py
@@ -36,3 +36,11 @@ class Treasury:
         self.usd_total = sum(
             asset.balance for asset in self.assets if asset.balance is not None
         )
+
+    def prune(self, symbol: str):
+        i = 0
+        for asset in self.assets:
+            if asset.token_symbol == symbol:
+                self.assets.pop(i)
+                break
+            i += 1


### PR DESCRIPTION
## Summary

Some tokens are not able to get a Coingecko response for a historical token price request.

The result was a `KeyError` when building a portfolio for an API response
```python
assets = {
    a.token_symbol: PortfolioAsset(
        allocation=a.balance / treasury.usd_total,
        volatility=histprices[a.token_symbol]["std_dev"].mean(),
        risk_contribution=a.risk_contribution,
    )
    for a in treasury.assets
}
```

The `KeyError` is encountered trying to get a historical price that does not exist for a given token `histprices[a.token_symbol]`.

This PR removes tokens from a portfolio that does not have a Coingecko historical price reponse.