### PR TITLE
 :sparkles: Added expiry on `hist_prices` hset name

### DIFF
--- a/backend/app/libs/coingecko/coins.py
+++ b/backend/app/libs/coingecko/coins.py
@@ -73,12 +73,15 @@ async def get_coin_hist_price(
         sleep(5)
         try:
             prices = resp.json().get("prices")
-            if prices is None:
-                return None
         except JSONDecodeError:
             print(f"decode error for {resp.url}")
             return None
 
     db.hset(CACHE_HASH, cache_key, json.dumps(prices))
+    # Set an expiry flag on this hset name for a day.
+    # It will only set an expire on this name if none exists for it.
+    db.expire(CACHE_HASH, 86400, nx=True)
 
+    if prices is None:
+        return None
     return (contract_address, symbol, prices)


### PR DESCRIPTION
## Summary
 This PR ensures troublesome tokens with no historical data are checked each day for fresh data from Coingecko (CG) whilst minimizing the number of http calls for these troublesome tokens.

## Details
There are some tokens that CG does not provide historical price data for. These tokens not having any historical prices causes issues for Whip which heavily relies on historical data. 

At the same time, if this is a temporary issue or if the token simply hasn't been tracked by CG yet then rather than never caching these tokens, this PR introduces caching with an expiry. 

This way we're caching regardless, [still pruning troublesome tokens](https://github.com/butterdao/whip/blob/main/backend/app/libs/tasks/get_assets.py#L51-L53), and checking each day if there is any historical price data for potentially temporary cases.