### PR TITLE
:bug: Added compatibility for redis v6 expiry command

### DIFF
--- a/backend/app/libs/coingecko/coins.py
+++ b/backend/app/libs/coingecko/coins.py
@@ -80,7 +80,8 @@ async def get_coin_hist_price(
     db.hset(CACHE_HASH, cache_key, json.dumps(prices))
     # Set an expiry flag on this hset name for a day.
     # It will only set an expire on this name if none exists for it.
-    db.expire(CACHE_HASH, 86400, nx=True)
+    if db.ttl(CACHE_HASH) <= 0:
+        db.expire(CACHE_HASH, 86400)
 
     if prices is None:
         return None

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   redis:
     profiles: ["backend"]
-    image: redis
+    image: redis:6.2.3
     networks:
       - whip_nw
     ports:


### PR DESCRIPTION
## Summary
The Heroku deployment of Whip uses Redis v6, which does not use the same number of arguments for the `expire` command as Redis v7 (which was used to test locally).

This `expire` command was introduced in PR #45 and introduced a bug because of this. This PR fixes this issue by replacing the `nx` argument with a expiry check on a given key. If the key has expired, then it will set the key and resets the expiry to a day again.

For more context on why this issue arises, [checkout out Redis' docs](https://redis.io/commands/expire/).