### PR TITLE
:bug: Ensure tasks are exported for scheduler

### DIFF
--- a/backend/app/libs/tasks/__init__.py
+++ b/backend/app/libs/tasks/__init__.py
@@ -1,0 +1,6 @@
+from .get_assets import (
+    reload_treasuries_stats,
+    reload_whitelist,
+    setup_init_tasks,
+    setup_periodic_tasks,
+)


### PR DESCRIPTION
## Summary
Commit 02dbf9f4fea3d33d1f329a8652ba7b2ba76f00fa removed exporting tasks required by the scheduler.

This PR ensures that tasks are exported so that they can be scheduled by Celery.