### PR TITLE
Fix/lone transfer ommitance

### DIFF
--- a/backend/app/libs/pd_inter_calc.py
+++ b/backend/app/libs/pd_inter_calc.py
@@ -1,5 +1,4 @@
 import datetime
-from typing import Optional
 
 import pandas as pd
 from dateutil.tz import UTC

--- a/backend/app/libs/pd_inter_calc.py
+++ b/backend/app/libs/pd_inter_calc.py
@@ -8,7 +8,7 @@ from dateutil.utils import today
 
 def make_daily_hist_balance(
     token_symbol: str, hist_transfer_balance: pd.Series, hist_price: pd.Series
-) -> Optional[pd.Series]:
+) -> pd.Series:
     def find_closest_quote(date: datetime.datetime) -> float:
         # For now, quote rates are not going as far back in time than portfolio
         # balances, so just return 0 if no quote
@@ -44,8 +44,6 @@ def make_daily_hist_balance(
         return _current_date
 
     rows = list(hist_transfer_balance.to_dict().items())
-    if len(rows) < 2:  # [FIXME]
-        return None
 
     for index, row in enumerate(rows):
         current_date = row[0].replace(hour=0, minute=0, second=0, microsecond=0)

--- a/backend/app/libs/tasks/get_assets.py
+++ b/backend/app/libs/tasks/get_assets.py
@@ -76,8 +76,7 @@ def reload_treasuries_stats():
                     *treasury_metadata, start, end
                 )
             except TypeError:
-                # This error is likely caused by
-                # backend.app.libs.pd_inter_calc.make_daily_hist_balance
+                # This currently only raises when the given treasury has no balance
                 logger.error(  # [FIXME]
                     "error reducing augemented treasury balance for %s",
                     treasury_metadata[0],

--- a/backend/app/treasury/actions.py
+++ b/backend/app/treasury/actions.py
@@ -42,10 +42,7 @@ async def _fill_asset_hist_balances(
     def fill_asset_hist_balance(
         symbol, augmented_token_hist_price
     ) -> Optional[pd.DataFrame]:
-        if (
-            symbol not in asset_transfer_balances
-            or len(asset_transfer_balances[symbol]) < 2
-        ):
+        if symbol not in asset_transfer_balances:
             return None
         return pd_inter_calc.make_daily_hist_balance(
             symbol, asset_transfer_balances[symbol], augmented_token_hist_price.price


### PR DESCRIPTION
## Summary

Fixes #51.

## Details

This PR will change the filter that removed treasuries with just a single transfer into one that:

* removes treasuries that have no transfer activity
* removes treasuries with no token balance

## Further improvements

To better handle treasuries that satisfy the new filter conditions listed above.

Currently the Whip scheduler [raises an error](https://github.com/butterdao/whip/blob/fix/lone_transfer_ommitance/backend/app/libs/tasks/get_assets.py#L78-L83) and moves on to the next treasury on the list of cached treasuries.

For the API, an `Internal Server Error` is raised by FastAPI. 