### PR TITLE
:sparkles: Add support for spreading with ETH

### DIFF
--- a/backend/app/endpoints.py
+++ b/backend/app/endpoints.py
@@ -130,8 +130,8 @@ async def backtest_spread(
     address: str,
     start: str,
     token_to_divest_from: str,
-    percentage: int = Path(0, ge=0, le=100),
     spread_token: str = Path("USDC", regex="(?:(^USDC$)|(^ETH$))"),
+    percentage: int = Path(0, ge=0, le=100),
 ):
     spread_tokens_metadatas = {
         "USDC": {

--- a/frontend/src/components/Product.tsx
+++ b/frontend/src/components/Product.tsx
@@ -50,7 +50,7 @@ export default function Product({
     const resp = await fetch(
       `/api/backtest/spread/${address}/${startDate
         .toISOString()
-        .slice(0, 10)}/${selectedAsset}/${percentage}`
+        .slice(0, 10)}/${selectedAsset}/USDC/${percentage}`
     );
     if (!resp.ok)
       throw new Error(`Backtest fetch failed with status: ${resp.statusText}`);


### PR DESCRIPTION
## Summary

Fixes #74

## Details

This PR adds a `spread_token` path to the `/backtest/spread/` endpoint on the backend API. If `USDC` is specified for this path, then the behaviour of this endpoint responds like it did prior to this PR, by giving the historical balances after the specified USDC diversification strategy is implemented.

If `ETH` is specified for `spread_token`, then the endpoint will return the historical balances if a ETH diversification strategy is implemented.

## Further improvements
- [ ] Frontend changes to Spread diversification strategy selection

Frontend will need to add an option for the user to choose between the two available strategies: USDC and ETH.

Once that's done, this PR should be ready to merge.