### PR TITLE
✨ Add Metrics TimeSeries

### DIFF
--- a/backend/app/libs/price_stats.py
+++ b/backend/app/libs/price_stats.py
@@ -18,7 +18,7 @@ def make_returns_df(hist_values: pd.Series, column_name: str) -> pd.DataFrame:
     dataframe.returns.replace(-np.inf, 0, inplace=True)
     dataframe.returns.iloc[1:].replace(
         np.nan, 0, inplace=True
-    )  # Keep first nan (probly useless).
+    )  # Keep first nan (probably useless).
     dataframe["std_dev"] = dataframe.returns.rolling(ROLLING_WINDOW_DAYS).std(ddof=0)
     return dataframe
 

--- a/backend/app/libs/series.py
+++ b/backend/app/libs/series.py
@@ -11,4 +11,4 @@ def make_hist_price_series(
         (price.value for price in prices),
         index=pd.Index((price.timestamp for price in prices), name="timestamp"),
         name=f"{token_symbol} historical price",
-    )
+    ).sort_index()


### PR DESCRIPTION
## Summary

Fixes #80

## Details

This PR exposes the historical 7-day avg standard deviation and historical returns to the `portfolio` endpoint.

The `volatility` property of each asset in this endpoint response will be replaced with `metrics` containing the historical std_dev as `volatility` and returns as `returns` as timeseries.

## Further Improvements
- [ ] Frontend changes to plot

The graph on the frontend will need to also plot these timeseries on the three timeframes (1-yr, 3-months, 1-month).