### PR TITLE
:sparkles: Add celery task to retry treasury stats

### DIFF
--- a/backend/app/libs/pd_inter_calc.py
+++ b/backend/app/libs/pd_inter_calc.py
@@ -46,6 +46,7 @@ def make_daily_hist_balance(
 
     for index, row in enumerate(rows):
         current_date = row[0].replace(hour=0, minute=0, second=0, microsecond=0)
+        current_balance = row[1]
         if index < len(rows) - 1:
             next_date = rows[index + 1][0].replace(
                 hour=0, minute=0, second=0, microsecond=0
@@ -55,7 +56,6 @@ def make_daily_hist_balance(
             if next_date > _today:
                 break
 
-        current_balance = row[1]
         current_date = fill_until(next_date, current_date)
 
     # Forward fill last dates from last balance change until today with

--- a/backend/app/libs/tests/conftest.py
+++ b/backend/app/libs/tests/conftest.py
@@ -1,0 +1,171 @@
+# pylint: disable=unused-argument
+# pylint: disable=redefined-outer-name
+import asyncio
+
+import pytest
+import pytest_asyncio
+from _pytest import monkeypatch
+from fakeredis import FakeRedis
+
+from ...treasury import actions
+from ...treasury.adapters import covalent_pricefeed
+from ...treasury.models import Transfer
+from .. import pd_inter_calc
+
+covalent_hist_prices_v2_transfers = [
+    {
+        "contract_decimals": 18,
+        "contract_name": "ABC Token",
+        "contract_ticker_symbol": "ABC",
+        "contract_address": "0x1a5f9352af8af974bfc03399e3767df6370d82e4",
+        "supports_erc": ["erc20"],
+        "logo_url": "",
+        "update_at": "2022-07-13T22:51:12.022553016Z",
+        "quote_currency": "USD",
+        "prices": [
+            {
+                "contract_metadata": {
+                    "contract_decimals": 18,
+                    "contract_name": "ABC Token",
+                    "contract_ticker_symbol": "ABC",
+                    "contract_address": "0x1a5f9352af8af974bfc03399e3767df6370d82e4",
+                    "supports_erc": ["erc20"],
+                    "logo_url": "",
+                },
+                "date": "2022-07-13",
+                "price": 0.28732044,
+            },
+            {
+                "contract_metadata": {
+                    "contract_decimals": 18,
+                    "contract_name": "ABC Token",
+                    "contract_ticker_symbol": "ABC",
+                    "contract_address": "0x1a5f9352af8af974bfc03399e3767df6370d82e4",
+                    "supports_erc": ["erc20"],
+                    "logo_url": "",
+                },
+                "date": "2022-07-12",
+                "price": 0.28529906,
+            },
+            {
+                "contract_metadata": {
+                    "contract_decimals": 18,
+                    "contract_name": "ABC Token",
+                    "contract_ticker_symbol": "ABC",
+                    "contract_address": "0x1a5f9352af8af974bfc03399e3767df6370d82e4",
+                    "supports_erc": ["erc20"],
+                    "logo_url": "",
+                },
+                "date": "2022-07-11",
+                "price": 0.28879964,
+            },
+            {
+                "contract_metadata": {
+                    "contract_decimals": 18,
+                    "contract_name": "ABC Token",
+                    "contract_ticker_symbol": "ABC",
+                    "contract_address": "0x1a5f9352af8af974bfc03399e3767df6370d82e4",
+                    "supports_erc": ["erc20"],
+                    "logo_url": "",
+                },
+                "date": "2022-07-10",
+                "price": 0.29183155,
+            },
+            {
+                "contract_metadata": {
+                    "contract_decimals": 18,
+                    "contract_name": "ABC Token",
+                    "contract_ticker_symbol": "ABC",
+                    "contract_address": "0x1a5f9352af8af974bfc03399e3767df6370d82e4",
+                    "supports_erc": ["erc20"],
+                    "logo_url": "",
+                },
+                "date": "2022-07-09",
+                "price": 0.29352316,
+            },
+        ],
+    }
+]
+
+
+class FakeCovalentResponse:
+    resp_json = {"data": covalent_hist_prices_v2_transfers}
+
+    status_code = None
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self.resp_json
+
+
+@pytest.fixture(scope="session")
+def event_loop():
+    return asyncio.get_event_loop()
+
+
+@pytest.fixture(scope="module")
+def monkeymodule(request):
+    _monkeypatch = monkeypatch.MonkeyPatch()
+    yield _monkeypatch
+    _monkeypatch.undo()
+
+
+@pytest_asyncio.fixture(scope="module")
+async def patch_covalent_pricefeed(monkeymodule):
+    async def _get_fake_covalent_resp(*_, **__):
+        return FakeCovalentResponse()
+
+    fake_provider = FakeRedis()
+    monkeymodule.setattr(
+        covalent_pricefeed,
+        "db",
+        fake_provider,
+        raising=True,
+    )
+
+    monkeymodule.setattr(
+        covalent_pricefeed.AsyncClient,
+        "get",
+        _get_fake_covalent_resp,
+        raising=True,
+    )
+
+
+@pytest.fixture(scope="module")
+def patch_today(monkeymodule):
+    monkeymodule.setattr(
+        pd_inter_calc,
+        "today",
+        lambda _: pd_inter_calc.datetime.datetime(
+            2022, 7, 12, 0, 0, 0, tzinfo=pd_inter_calc.UTC
+        ),
+    )
+
+
+@pytest_asyncio.fixture(scope="module")
+async def patch_get_token_transfers(monkeymodule):
+    async def _implem(*_):
+        return [
+            Transfer(
+                timestamp=pd_inter_calc.datetime.datetime(
+                    year=2022,
+                    month=7,
+                    day=12,
+                    hour=22,
+                    minute=59,
+                    tzinfo=pd_inter_calc.UTC,
+                ),
+                amount=1,
+            ),
+        ]
+
+    monkeymodule.setattr(actions, "get_token_transfers", _implem)
+
+
+@pytest_asyncio.fixture(scope="module")
+async def setup_single_transfer_test(
+    patch_covalent_pricefeed, patch_today, patch_get_token_transfers
+):
+    pass

--- a/backend/app/libs/tests/test_pd_inter_calc.py
+++ b/backend/app/libs/tests/test_pd_inter_calc.py
@@ -1,0 +1,41 @@
+# pylint: disable=unused-argument
+# pylint: disable=redefined-outer-name
+import pytest
+
+from ...treasury import actions
+from ...treasury.models import ERC20, Treasury
+
+
+@pytest.mark.asyncio
+async def test_single_tranfer_balance_lt_24hrs_after_transfer(
+    setup_single_transfer_test,
+):
+    treasury = Treasury(
+        address="0x0",
+        assets=[
+            ERC20(
+                token_name="abc",
+                token_symbol="ABC",
+                token_address="0xabc",
+                balance=1000,
+                balance_usd=285.29906,
+            ),
+        ],
+    )
+
+    balances_and_transfers = await actions.make_transfers_balances_for_treasury(
+        treasury
+    )
+    prices = await actions.make_prices_from_tokens({("ABC", "0xabc")})
+
+    balances = await actions.make_balances_from_transfers_and_prices(
+        balances_and_transfers, prices
+    )
+    print(balances)
+
+    abc_price_for_date_of_last_transfer = prices.prices["ABC"]["price"].iloc[-2]
+    abc_current_balance = treasury.assets[0].balance
+    assert (
+        balances.usd_balances["ABC"].iloc[-1]
+        == abc_price_for_date_of_last_transfer * abc_current_balance
+    )

--- a/backend/app/treasury/adapters/covalent/portfolio_v2.py
+++ b/backend/app/treasury/adapters/covalent/portfolio_v2.py
@@ -1,4 +1,3 @@
-# pylint: disable=duplicate-code
 import json
 from os import getenv
 from typing import Any, Optional
@@ -18,7 +17,7 @@ CACHE_KEY_TEMPLATE_PORTFOLIO = "{address}_{chain_id}_{date}"
 async def _get_portfolio_data(
     treasury_address: str, chain_id: Optional[int] = 1
 ) -> dict[str, Any]:
-    timeout = Timeout(10.0, read=60.0, connect=90.0)
+    timeout = Timeout(10.0, read=90.0, connect=120.0)
     async with AsyncClient(timeout=timeout) as client:
         url = (
             f"https://api.covalenthq.com/v1/{chain_id}/address/{treasury_address}/"
@@ -52,11 +51,14 @@ async def get_treasury(
             logger = get_logger(__name__)
             if error.__class__ is HTTPStatusError:
                 logger.error(
-                    "unable to receive a Covalent `portfolio_v2` API response",
+                    "unable to receive a Covalent `portfolio_v2` API response for %s",
+                    treasury_address,
                     exc_info=error,
                 )
             logger.error(
-                "error processing Covalent `portfolio_v2` API response", exc_info=error
+                "error processing Covalent `portfolio_v2` API response for %s",
+                treasury_address,
+                exc_info=error,
             )
             raise
 

--- a/backend/app/treasury/adapters/redis.py
+++ b/backend/app/treasury/adapters/redis.py
@@ -20,7 +20,7 @@ def store_treasuries_metadata(
 def retrieve_treasuries_metadata(
     provider: Union[redis.Redis, redis.client.Pipeline]
 ) -> set[tuple[str, int]]:
-    treasuries = [
+    treasuries: list[tuple[str, int]] = [
         tuple(json.loads(t).values()) for t in provider.smembers("treasuries")
     ]
     return set(treasuries)

--- a/backend/app/treasury/tests/adapters/covalent/test_covalent_pricefeed.py
+++ b/backend/app/treasury/tests/adapters/covalent/test_covalent_pricefeed.py
@@ -6,8 +6,7 @@ from dateutil.tz import UTC
 from fakeredis import FakeRedis
 from pytest import MonkeyPatch, mark
 
-from backend.app.treasury.adapters import covalent_pricefeed
-
+from ....adapters import covalent_pricefeed
 from .conftest import covalent_hist_prices_v2_transfers, mocked_datetime
 
 
@@ -31,13 +30,15 @@ async def _get_fake_covalent_resp(*_, **__):
 async def test_get_coin_hist_price_redis(monkeypatch: MonkeyPatch):
     fake_provider = FakeRedis()
     monkeypatch.setattr(
-        "backend.app.treasury.adapters.covalent_pricefeed.db",
+        covalent_pricefeed,
+        "db",
         fake_provider,
         raising=True,
     )
 
     monkeypatch.setattr(
-        "backend.app.treasury.adapters.covalent_pricefeed.AsyncClient.get",
+        covalent_pricefeed.AsyncClient,
+        "get",
         _get_fake_covalent_resp,
         raising=True,
     )
@@ -63,13 +64,15 @@ async def test_get_coin_hist_price_redis(monkeypatch: MonkeyPatch):
 async def test_get_coin_hist_price(monkeypatch: MonkeyPatch):
     fake_provider = FakeRedis()
     monkeypatch.setattr(
-        "backend.app.treasury.adapters.covalent_pricefeed.db",
+        covalent_pricefeed,
+        "db",
         fake_provider,
         raising=True,
     )
 
     monkeypatch.setattr(
-        "backend.app.treasury.adapters.covalent_pricefeed.AsyncClient.get",
+        covalent_pricefeed.AsyncClient,
+        "get",
         _get_fake_covalent_resp,
         raising=True,
     )


### PR DESCRIPTION
## Summary
Addresses #66

## Details

A celery task to retry treasury stats was added to whip that happens periodically.
Every hour this task attempts to retry getting covalent data to be cached.

Also, a small bug regarding the balance builder logic is fixed. The bug in question was caused when a treasury had a single transfer occurring < 24 hrs from time of execution.