### PR TITLE
🔨 Create a script to CSV-extract volatility

### DIFF
--- a/backend/dev-requirements.txt
+++ b/backend/dev-requirements.txt
@@ -1,6 +1,7 @@
 -i https://pypi.org/simple
 -r requirements.txt
 black==22.3.0
+clize>=4.2.1
 fakeredis==1.8.1
 flake8==4.0.1
 isort==5.10.1

--- a/backend/scripts/README.md
+++ b/backend/scripts/README.md
@@ -1,0 +1,32 @@
+# Setup
+
+## How to run a script
+
+First, make sure your docker compose is up (we need the Redis instance running).
+
+Then, in a shell:
+
+- cd in the `backend` folder
+- make sure the `.env` file is loaded in your shell environment
+- run with, eg, `REDIS_URL=redis://localhost:6379 python -m scripts.volacsv …`
+
+# Scripts
+
+## volacsv
+
+This will output a CSV with 7day std dev ("volatility") of USD quotation, for assets of a given
+portfolio.
+
+By default, (start, end) dates are (1y ago - 1d, yesteraday).
+
+Example usage:
+
+```sh
+REDIS_URL=redis://localhost:6379 python -m scripts.volacsv 0x567d220b0169836cbf351df70a9c517096ec9de7 > primedao-$(date +'%Y-%m-%d').csv
+```
+
+You can define start and end dates as well:
+
+```sh
+REDIS_URL=redis://localhost:6379 python -m scripts.volacsv 0x567d220b0169836cbf351df70a9c517096ec9de7 2022-01-01 2022-04-01 > primedao-2022-01-01-2022-04-01.csv
+```

--- a/backend/scripts/volacsv.py
+++ b/backend/scripts/volacsv.py
@@ -1,0 +1,51 @@
+# pylint: disable=wrong-import-position
+# pylint: disable=import-error
+
+import asyncio
+import datetime
+import sys
+from functools import reduce
+
+import dateutil
+import dotenv
+from clize import run
+from pytz import UTC
+
+dotenv.load_dotenv()
+
+from app.treasury import build_treasury_with_assets
+
+
+def get_volatility(
+    address: str,
+    start: str = "",
+    end: str = "",
+):
+    today = dateutil.utils.today(UTC)
+    end = end or (today - datetime.timedelta(days=1)).strftime("%Y-%m-%d")
+    start = start or (today - datetime.timedelta(days=366)).strftime("%Y-%m-%d")
+    assert start < end
+
+    treasury, prices, __, ___ = asyncio.run(
+        build_treasury_with_assets(address, 1, start, end)
+    )
+
+    asset_symbols = [asset.token_symbol for asset in treasury.assets]
+
+    vola_df = reduce(
+        lambda acc, df: acc.merge(df, on="timestamp", how="outer"),
+        [
+            prices.prices[symb][["price"]].rename(columns={"price": symb})
+            for symb in asset_symbols
+        ],
+    )
+    vola_df.reset_index(inplace=True)
+    vola_df["date"] = vola_df.timestamp.dt.date
+    vola_df.set_index("date", inplace=True)
+    del vola_df["timestamp"]
+
+    sys.stdout.write(vola_df.to_csv())
+
+
+if __name__ == "__main__":
+    run(get_volatility)


### PR DESCRIPTION
@vaughnmck a simple solution in response to https://github.com/butterdao/whip/issues/80

See `backend/scripts/README.md` for details on how to run.

The results look like attached.
[primedao-2022-08-04.csv](https://github.com/butterdao/whip/files/9262092/primedao-2022-08-04.csv)

