### PR TITLE
:bug: Fix `Balances` dict property post-refractor

### DIFF
--- a/backend/app/libs/tasks/get_assets.py
+++ b/backend/app/libs/tasks/get_assets.py
@@ -131,7 +131,7 @@ def reload_treasuries_stats(
                     pipe,
                 )
 
-            for symbol, asset_hist_balance in asset_hist_balances.balances.items():
+            for symbol, asset_hist_balance in asset_hist_balances.usd_balances.items():
                 store_asset_hist_balance(
                     treasury.address,
                     symbol,


### PR DESCRIPTION
## Summary

Hot fix for scheduler after recent refractor of `Balances` model.

`Balances.balances` is now `Balances.usd_balances`, thus this change needs to be reflected in the scheduler defined in `get_assets`.