### PR TITLE
:sparkles: Add manual expiry to Redis keys

### DIFF
--- a/backend/app/endpoints.py
+++ b/backend/app/endpoints.py
@@ -118,7 +118,7 @@ async def get_portfolio(address: str, start=str):
     end = end_date.strftime("%Y-%m-%d")
 
     portfolio = Portfolio.from_treasury_with_assets(
-        *(await build_treasury_with_assets(address, 1, start, end)),
+        *(await build_treasury_with_assets(((address, 1), start, end))),
         start,
         end,
     )

--- a/backend/app/libs/tasks/redis.py
+++ b/backend/app/libs/tasks/redis.py
@@ -1,7 +1,9 @@
 import json
+from datetime import datetime, timedelta
 from typing import Any, Union
 
 import redis
+from dateutil.tz import UTC
 
 BALANCES_KEY_TEMPLATE = "{address}_{symbol}"
 
@@ -34,6 +36,12 @@ def store_hash_set(
     provider: Union[redis.Redis, redis.client.Pipeline],
 ):
     provider.hset(_hash, key, value)
+
+    time_to_evict = datetime.now(tz=UTC) + timedelta(days=1)
+    provider.expireat(
+        _hash,
+        time_to_evict.replace(hour=0, minute=0, second=0),
+    )
 
 
 def store_asset_hist_balance(

--- a/backend/app/token_whitelists/adapters/redis.py
+++ b/backend/app/token_whitelists/adapters/redis.py
@@ -1,3 +1,4 @@
+from datetime import timedelta
 from typing import Union
 
 import redis
@@ -9,6 +10,7 @@ def store_token_whitelist(
     address: list[str], provider: Union[redis.Redis, redis.client.Pipeline]
 ):
     provider.sadd("whitelist", *address)
+    provider.expire("whitelist", timedelta(days=1))
 
 
 def retrieve_token_whitelist(

--- a/backend/app/treasury/__init__.py
+++ b/backend/app/treasury/__init__.py
@@ -10,6 +10,7 @@ from .actions import (
 )
 from .adapters import (
     get_treasury_list,
+    remove_treasuries_metadata,
     retrieve_treasuries_metadata,
     store_treasuries_metadata,
 )

--- a/backend/app/treasury/adapters/__init__.py
+++ b/backend/app/treasury/adapters/__init__.py
@@ -1,2 +1,7 @@
 from .cryptostats import get_treasury_list
-from .redis import retrieve_treasuries_metadata, store_treasuries_metadata
+from .redis import (
+    remove_treasuries_metadata,
+    retrieve_treasuries_metadata,
+    set_data_and_expiry,
+    store_treasuries_metadata,
+)

--- a/backend/app/treasury/adapters/redis.py
+++ b/backend/app/treasury/adapters/redis.py
@@ -1,7 +1,9 @@
 import json
+from datetime import datetime, timedelta
 from typing import Union
 
 import redis
+from dateutil.tz import UTC
 
 CHAIN_ID = 1
 
@@ -11,16 +13,39 @@ def store_treasuries_metadata(
     addresses: list[Union[str, None]],
     chain_id: int = CHAIN_ID,
 ):
-    payload = [
-        json.dumps({"address": address, "chain_id": chain_id}) for address in addresses
-    ]
+    payload = [json.dumps((address, chain_id)) for address in addresses]
     provider.sadd("treasuries", *payload)
+
+
+def remove_treasuries_metadata(
+    provider: Union[redis.Redis, redis.client.Pipeline],
+):
+    provider.delete("treasuries")
 
 
 def retrieve_treasuries_metadata(
     provider: Union[redis.Redis, redis.client.Pipeline]
 ) -> set[tuple[str, int]]:
-    treasuries: list[tuple[str, int]] = [
-        tuple(json.loads(t).values()) for t in provider.smembers("treasuries")
-    ]
+    treasuries = [tuple(json.loads(t)) for t in provider.smembers("treasuries")]
     return set(treasuries)
+
+
+def retrieve_hist_prices(
+    symbol: str, provider: Union[redis.Redis, redis.client.Pipeline]
+):
+    provider.hget("asset_hist_performance", symbol)
+
+
+def set_data_and_expiry(
+    cache_key: str,
+    data_to_set: str,
+    provider: Union[redis.Redis, redis.client.Pipeline],
+):
+    provider.set(cache_key, data_to_set)
+    if provider.ttl(cache_key) <= 0:
+        time_to_evict = datetime.now(tz=UTC) + timedelta(days=1)
+        time_to_evict_ts = time_to_evict.replace(
+            hour=0, minute=0, second=0, microsecond=0
+        ).timestamp()
+
+    provider.expireat(cache_key, int(time_to_evict_ts))


### PR DESCRIPTION
## Summary
Fixes #93

## Details
Expiries were explicitly set for data keys, each set to 1 day.